### PR TITLE
Update gameCompatibility.json

### DIFF
--- a/gameCompatibility.json
+++ b/gameCompatibility.json
@@ -3350,7 +3350,7 @@
     "Genre": "Shooter",
     "MultiplayerType": 4,
     "MultiplayerDetails": null,
-    "NvidiaSupport": 4,
+    "NvidiaSupport": 0,
     "AmdSupport": 3,
     "IntelSupport": 4,
     "SetupDetails": [
@@ -3362,7 +3362,7 @@
     ],
     "CommonIssues": [],
     "FeaturesNotEmulated": [],
-    "OverallStatus": 4
+    "OverallStatus": 1
   },
   {
     "Id": "HOTDSD",

--- a/gameCompatibility.json
+++ b/gameCompatibility.json
@@ -3351,7 +3351,7 @@
     "MultiplayerType": 4,
     "MultiplayerDetails": null,
     "NvidiaSupport": 4,
-    "AmdSupport": 4,
+    "AmdSupport": 3,
     "IntelSupport": 4,
     "SetupDetails": [
       {

--- a/gameCompatibility.json
+++ b/gameCompatibility.json
@@ -1683,7 +1683,7 @@
     "MultiplayerType": 4,
     "MultiplayerDetails": null,
     "NvidiaSupport": 0,
-    "AmdSupport": 4,
+    "AmdSupport": 0,
     "IntelSupport": 4,
     "SetupDetails": [
       {


### PR DESCRIPTION
A little change for GPU Compatibility status, Daytona Championship USA NSE works the same as the original version and is working on AMD without any shader fix or problems whatsoever. Tested on RX Vega 6 iGPU.